### PR TITLE
Remove diagnostic report entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,6 @@ yarn-error.log*
 lerna-debug.log*
 .pnpm-debug.log*
 
-# Diagnostic reports (https://nodejs.org/api/report.html)
-report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
-
 # Runtime data
 pids
 *.pid


### PR DESCRIPTION
Eliminate the exclusion of diagnostic report files from .gitignore to allow tracking of these reports in the repository.